### PR TITLE
Add `restart_add_minerals` runtime flag to apply additive mineral initialization on restart

### DIFF
--- a/Source/CrunchTope.F90
+++ b/Source/CrunchTope.F90
@@ -996,6 +996,20 @@ IF (irestart == 1) THEN
                delt,dtold,tstep,deltmin,dtmaxcour,dtmax,userC,userD,userP,user,     &
                amatpetsc,amatD,amatP,bvec,xvec,bvecD,xvecD,bvecP,xvecP)
 
+  IF (RestartAddMinerals) THEN
+    WRITE(*,*) ' Applying restart_add_minerals option: adding input mineral volumes to restart state'
+    DO jz = 1,nz
+      DO jy = 1,ny
+        DO jx = 1,nx
+          DO k = 1,nrct
+            volfx(k,jx,jy,jz) = volfx(k,jx,jy,jz) + volin(k,jinit(jx,jy,jz))
+            VolumeLastTimeStep(k,jx,jy,jz) = volfx(k,jx,jy,jz)
+          END DO
+        END DO
+      END DO
+    END DO
+  END IF
+
 END IF
 
 

--- a/Source/RunTime.F90
+++ b/Source/RunTime.F90
@@ -74,6 +74,7 @@ MODULE runtime
   LOGICAL(LGT)                                                :: kaleidagraph
   LOGICAL(LGT)                                                :: nview
   LOGICAL(LGT)                                                :: AppendRestart
+  LOGICAL(LGT)                                                :: RestartAddMinerals
   LOGICAL(LGT)                                                :: Cylindrical
   LOGICAL(LGT)                                                :: Rectangular
   LOGICAL(LGT)                                                :: Spherical

--- a/Source/StartTope.F90
+++ b/Source/StartTope.F90
@@ -733,6 +733,7 @@ ihindmarsh = 1
 GIMRT = .TRUE.
 petscon = .TRUE.
 AppendRestart = .FALSE.
+RestartAddMinerals = .FALSE.
 nCSD = 500
 time_scale = 1.0d0
 dist_scale = 1.0d0
@@ -1568,6 +1569,11 @@ IF (found) THEN
     irestart = 1
   END IF
 
+  parchar = 'restart_add_minerals'
+  parfind = ' '
+  RestartAddMinerals = .FALSE.
+  CALL read_logical(nout,lchar,parchar,parfind,RestartAddMinerals)
+
   parchar = 'save_restart'
   parfind = ' '
   RestartOutputFile = ' '
@@ -1770,6 +1776,7 @@ ELSE
   ihindmarsh = 1
   ScreenInterval = 1
   RestartOutputFile = 'crunch.rst'
+  RestartAddMinerals = .FALSE.
   NumInputFiles = 1
   InputFileCounter = 1
   KateMaher = .FALSE.

--- a/docs/input_file/runtime.md
+++ b/docs/input_file/runtime.md
@@ -558,6 +558,19 @@ example, pHn.dat) will be updated as well if this *append* option is
 chose, so spatial profiles written after restart will reflect the files
 written previously before restart.
 
+
+#### Restart_add_minerals
+
+Option to add mineral volume fractions from the new input file on top of a restart state.
+
+Syntax:  **restart_add_minerals** *logical*
+
+*logical* is a standard FORTRAN logical (true or false).
+
+<u> Default </u>: false
+
+Explanation:  When **restart_add_minerals** is true and a **restart** file is used, CrunchTope first reads the full depth-resolved mineral volume fractions from the restart file, then adds the mineral volume fractions defined by each grid cell's geochemical condition in the current input file. This allows users to preserve the previous simulation end-state while incrementing minerals for the new run. If false, restart behavior is unchanged and mineral volume fractions are taken only from the restart file.
+
 #### Save_restart
 
 Option to save a restart file.


### PR DESCRIPTION
### Motivation
- Provide an option to increment mineral volume fractions from the current input file on top of a binary restart state so users can preserve a prior end-state while adding new minerals.

### Description
- Added a new runtime logical `RestartAddMinerals` in `Source/RunTime.F90` to represent the `restart_add_minerals` option.
- Initialized the flag to `.FALSE.` in startup/default paths in `Source/StartTope.F90` and parsed the `restart_add_minerals` keyword with `CALL read_logical` during input processing.
- Implemented post-restart behavior in `Source/CrunchTope.F90` so that after `CALL restart(...)` and when `RestartAddMinerals` is true the code adds `volin(k,jinit(jx,jy,jz))` to `volfx(k,jx,jy,jz)` for all cells and syncs `VolumeLastTimeStep` to the updated `volfx` values.
- Documented the new keyword and behavior in `docs/input_file/runtime.md` including syntax and default (`false`).

### Testing
- Verified keyword wiring and references with `rg -n "restart_add_minerals|RestartAddMinerals"` across modified source and docs files, which succeeded.
- Inspected changes with `git diff --` and confirmed the intended edits to `Source/RunTime.F90`, `Source/StartTope.F90`, `Source/CrunchTope.F90`, and `docs/input_file/runtime.md`, which succeeded.
- Committed the changes with `git commit` and verified working tree with `git status --short`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699156abab348327aac48b0b5b070034)