### PR TITLE
Enforce unique linking for secondary surface complexes and fix init call arguments

### DIFF
--- a/Source/StartTope.F90
+++ b/Source/StartTope.F90
@@ -503,6 +503,7 @@ INTEGER(I4B)                                                  :: id
 INTEGER(I4B)                                                  :: nisotope_max
 INTEGER(I4B)                                                  :: nmindecay_max
 INTEGER(I4B)                                                  :: kd
+INTEGER(I4B)                                                  :: nlink
 INTEGER(I4B)                                                  :: ndim1
 INTEGER(I4B)                                                  :: ndim2
 INTEGER(I4B)                                                  :: ndim3
@@ -2521,12 +2522,29 @@ END DO
 
 !  Link the various secondary surface complexes to a primary surface hydroxyl site
 
+islink = 0
+
 DO ns = 1,nsurf_sec
+  nlink = 0
   DO is = 1,nsurf
     IF (musurf(ns,is+ncomp) /= 0.0) THEN
       islink(ns) = is
+      nlink = nlink + 1
     END IF
   END DO
+  IF (nlink == 0) THEN
+    WRITE(*,*)
+    WRITE(*,*) ' Secondary surface complex does not link to any primary surface site'
+    WRITE(*,*) ' Secondary surface complex: ', namsurf_sec(ns)
+    WRITE(*,*)
+    STOP
+  ELSE IF (nlink > 1) THEN
+    WRITE(*,*)
+    WRITE(*,*) ' Secondary surface complex links to more than one primary surface site'
+    WRITE(*,*) ' Secondary surface complex: ', namsurf_sec(ns)
+    WRITE(*,*)
+    STOP
+  END IF
 END DO
 
 nptlink = 0
@@ -3360,8 +3378,8 @@ DO nco = 1,nchem
 
   CALL species_init(ncomp,nspec)
   CALL gases_init(ncomp,ngas,tempc,nco)
-  CALL surf_init(ncomp,nspec,nsurf,nsurf_sec,nchem)
-  CALL exchange_init(ncomp,nspec,nexchange,nexch_sec,nchem)
+  CALL surf_init(ncomp,nspec,nsurf,nsurf_sec,nco)
+  CALL exchange_init(ncomp,nspec,nexchange,nexch_sec,nco)
   CALL totconc_init(ncomp,nspec,nexchange,nexch_sec,nsurf,nsurf_sec,nco)
   CALL totgas_init(ncomp,nspec,ngas)
   CALL totsurf_init(ncomp,nsurf,nsurf_sec)
@@ -10107,4 +10125,3 @@ STOP
 
   END SUBROUTINE StartTope
   
-

--- a/Source/surf_init.F90
+++ b/Source/surf_init.F90
@@ -71,6 +71,12 @@ REAL(DP)                                                    :: LogTotalSites
 REAL(DP)                                                    :: LogTotalEquivalents
 REAL(DP)                                                    :: LogDependence
 
+! NOTE:
+! Primary (basis) surface species concentrations are initialized by the caller
+! (e.g., StartTope sets spsurftmp10(1:nsurf) from guess_surf/c_surf before
+! calling this routine).  This routine computes the secondary surface species
+! (indices nsurf+1 : nsurf+nsurf_sec) from mass-action relationships.
+
 DO ns = 1,nsurf_sec
 
   IF (nptlink(ns) /= 0) THEN


### PR DESCRIPTION
### Motivation
- Ensure each secondary surface complex links to exactly one primary surface site and fail fast with a clear error if not.
- Fix incorrect argument being passed to initialization routines so they receive the correct coordinate/component index (`nco`) instead of `nchem`.
- Clarify behavior: primary surface species are initialized by the caller while this routine computes secondary surface species from mass-action relationships.

### Description
- Declared a new local `nlink` in `StartTope.F90` and initialize `islink` to zero before linking loops to ensure deterministic state.  Added logic to count links per secondary surface complex and set `islink(ns)` and `nptlink(ns)` accordingly.
- Added runtime checks in `StartTope.F90` to `STOP` with clear messages when a secondary surface complex links to zero or more than one primary surface site.
- Changed calls in `StartTope.F90` to pass `nco` to `surf_init` and `exchange_init` (previously passed `nchem`), matching the callable signatures and intent.
- Added a clarifying comment to `surf_init.F90` documenting that primary (basis) surface species are initialized by the caller and that this routine computes secondary surface species indices `nsurf+1:nsurf+nsurf_sec`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d481afc284832798b58c1fd7452e77)