### PR TITLE
Add SolidDensity and unit-conversion notes to SURFACE_COMPLEXATION docs

### DIFF
--- a/docs/input_file/surface_complexation.md
+++ b/docs/input_file/surface_complexation.md
@@ -17,3 +17,76 @@ followed by the keyword *--no_edl*, for example:
 
 The capability for surface complexation on the bulk material will be
 added soon.
+
+### Notes on `SolidDensity` and surface complexation calculations
+
+For surface complexation on a **specific mineral** (the currently
+supported mode), the site inventory is computed from:
+
+- site density (mol sites / m^2 mineral),
+- specific surface area (m^2 / g mineral), and
+- mineral abundance (from mineral moles or mineral volume fraction).
+
+In other words, the core surface-site calculation is mineral-based and
+does **not** directly use the `SolidDensity` input.
+
+`SolidDensity` does still affect conversions for reported units such as
+`mol/g solid` via the bulk solid:solution ratio, and it is also used by
+bulk-material exchange calculations. When `SolidDensity` is not directly
+prescribed (or is set to `CalculateFromMinerals`), the code can compute a
+bulk solid density from mineral volume fractions together with mineral
+molecular weights and molar volumes.
+
+### Unit conversions used in printed surface-complexation output
+
+The speciation/equilibrium output tables commonly print three related
+quantities:
+
+- `Sites/kgw` (or `Moles/kgw`)  
+- `Mol/g solid` (or `Sites/g solid`)  
+- `Mol/m^3 bulk` (or `Sites/BulkVolume(m^3)`)
+
+The code builds a temporary bulk solid:solution ratio for these
+conversions as:
+
+$$
+\mathrm{SolidSolutionRatioTemp} = 1000\cdot \rho_s \cdot (1-\phi)
+$$
+
+where $\rho_s$ is `SolidDensity` (kg/m$^3$) and $\phi$ is porosity.
+Because $1\ \mathrm{kg}=1000\ \mathrm{g}$ and $(1-\phi)$ is the solid
+volume fraction, this has units of grams of solid per cubic meter bulk
+medium (numerically equivalent to g/L bulk).
+
+From there, printed conversions are:
+
+1.  **Sites/kgw $\rightarrow$ Sites/g solid**
+
+    $$
+    C_{\mathrm{g\ solid}}=\frac{C_{\mathrm{kgw}}}
+    {\mathrm{SolidSolutionRatio}}
+    $$
+
+    (implemented as `.../SolidSolutionRatioTemp` in speciation output).
+
+2.  **Sites/kgw $\rightarrow$ Sites/m$^3$ bulk**
+
+    $$
+    C_{\mathrm{bulk}} = C_{\mathrm{kgw}}\cdot \phi \cdot \rho_w
+    $$
+
+    where $\rho_w$ is fluid density (`rocond`, kg/m$^3$). This appears in
+    equilibrium/speciation print routines as multiplication by
+    `porcond*rocond`.
+
+3.  **Inverse conversion (for context): Sites/m$^3$ bulk $\rightarrow$
+    Sites/kgw**
+
+    $$
+    C_{\mathrm{kgw}}=\frac{C_{\mathrm{bulk}}}{\phi\cdot \rho_w}
+    $$
+
+    In the code this factor is often represented by `AqueousToBulk`.
+
+If `SolidSolutionRatio` is zero, the code prints `0.0` in the
+`Mol/g solid` column to avoid divide-by-zero.


### PR DESCRIPTION
### Motivation

- Clarify how surface-site inventories are computed for surface complexation on a specific mineral and reduce confusion about the role of `SolidDensity` in those calculations.
- Document the temporary bulk solid:solution ratio and the exact unit conversions used in printed speciation/equilibrium output to make output interpretation reproducible.
- Explain behavior when `SolidDensity` is computed (`CalculateFromMinerals`) and when `SolidSolutionRatio` is zero to prevent unexpected divide-by-zero interpretations.

### Description

- Extended `docs/input_file/surface_complexation.md` with a new section `Notes on SolidDensity and surface complexation calculations` that states site inventories are computed from site density, specific surface area, and mineral abundance and that `SolidDensity` does not directly affect mineral-based site calculations.
- Added explanation that `SolidDensity` still affects reported unit conversions and can be computed from mineral volume fractions when set to `CalculateFromMinerals`.
- Added a `Unit conversions used in printed surface-complexation output` section that defines `SolidSolutionRatioTemp` (as `1000 * rho_s * (1-phi)`) and the three printed conversion formulas, including the implementation references to `SolidSolutionRatioTemp`, `porcond*rocond`, and `AqueousToBulk` used in the code.
- Documented the fallback behavior that the code prints `0.0` in the `Mol/g solid` column when `SolidSolutionRatio` is zero to avoid divide-by-zero errors.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e19acd40288327862fe96a33fce42d)